### PR TITLE
View contour in scg format

### DIFF
--- a/client/js/Core/main.js
+++ b/client/js/Core/main.js
@@ -90,25 +90,45 @@ SCWeb.core.Main = {
 
     systemIdentifierParameterProcessed(urlObject) {
         const sys_id = urlObject['sys_id'];
-        const scg_view = urlObject['scg_view'];
+        const scg_view = urlObject['scg_structure_view_only'];
         if (sys_id) {
             SCWeb.core.Main.doDefaultCommandWithSystemIdentifier([sys_id]);
             window.history.replaceState(null, null, window.location.pathname);
-            if (scg_view != undefined){
+            if (scg_view){
                 $('#window-header-tools').hide();
                 $('#static-window-container').hide();
                 $('#header').hide();
                 $('#footer').hide();
-                setTimeout(function(){
+                $('#window-container').css({'padding-right':'', 'padding-left':''});
+                this.waitForElm('.sc-contour').then(() => {
                     $('#window-container').children().children().children().children().hide();
                     $('.sc-contour').css({'height':'97%','width':'97%','position':'absolute'});
-                    $('.scs-scn-view-toogle-button').hide();
-                    $('.scs-scn-view-toogle-button').click();
-                }, 1000)
+                    $('.scs-scn-view-toogle-button').hide().click();
+                });
             }
             return true;
         }
         return false;
+    },
+
+    waitForElm(selector) {
+        return new Promise(resolve => {
+            if (document.querySelector(selector)) {
+                return resolve(document.querySelector(selector));
+            }
+    
+            const observer = new MutationObserver(mutations => {
+                if (document.querySelector(selector)) {
+                    resolve(document.querySelector(selector));
+                    observer.disconnect();
+                }
+            });
+    
+            observer.observe(document.body, {
+                childList: true,
+                subtree: true
+            });
+        });
     },
 
     commandParameterProcessed(urlObject) {

--- a/client/js/Core/main.js
+++ b/client/js/Core/main.js
@@ -90,9 +90,22 @@ SCWeb.core.Main = {
 
     systemIdentifierParameterProcessed(urlObject) {
         const sys_id = urlObject['sys_id'];
+        const scg_view = urlObject['scg_view'];
         if (sys_id) {
             SCWeb.core.Main.doDefaultCommandWithSystemIdentifier([sys_id]);
             window.history.replaceState(null, null, window.location.pathname);
+            if (scg_view != undefined){
+                $('#window-header-tools').hide();
+                $('#static-window-container').hide();
+                $('#header').hide();
+                $('#footer').hide();
+                setTimeout(function(){
+                    $('#window-container').children().children().children().children().hide();
+                    $('.sc-contour').css({'height':'97%','width':'97%','position':'absolute'});
+                    $('.scs-scn-view-toogle-button').hide();
+                    $('.scs-scn-view-toogle-button').click();
+                }, 1000)
+            }
             return true;
         }
         return false;


### PR DESCRIPTION
Add ability to view contour in scg format as on picture:
![scg_view](https://user-images.githubusercontent.com/43759605/149291399-ef9b7974-d970-48c1-8a2d-0a94e7538dd0.png)
To do this you need to post system identifier of contour and scg_structure_view_only as parameters like this
`http://localhost:8000/?sys_id=answer_structure&scg_structure_view_only=true`
 
#### Contour example:
```
answer_structure = [* 
    ...b <= nrel_sc_text_translation: ...a;;
    ...a -> [Hello!!!];;
*];;

```